### PR TITLE
parser: message priority

### DIFF
--- a/parser/parser.py
+++ b/parser/parser.py
@@ -14,7 +14,8 @@ class VkParser(object):
         self.vk_session = self.connect_vk(secret['login'], secret['password'])
         self.vk = self.vk_session.get_api()
 
-    def connect_vk(self, login, password):
+    @staticmethod
+    def connect_vk(login, password):
         session = vk_api.VkApi(login, password)
         try:
             session.auth()
@@ -84,7 +85,7 @@ if __name__ == '__main__':
 
     connection = pika.BlockingConnection(pika.ConnectionParameters(host='queue'))
     channel = connection.channel()
-    channel.queue_declare(queue='user_id')
+    channel.queue_declare(queue='user_id', arguments={'x-max-priority': 3})
 
     channel.basic_qos(prefetch_count=1)
     channel.basic_consume(on_request, queue='user_id')

--- a/tg_bot/bot.py
+++ b/tg_bot/bot.py
@@ -12,6 +12,7 @@ from telegram.ext import Updater
 MIN_NOVELTY_LEVEL = 1
 MAX_NOVELTY_LEVEL = 150
 DEFAULT_NOVELTY_LEVEL = 8
+TG_BOT_PRIORITY = 2  # message priority in queue higher is better
 
 
 def start(bot, update):
@@ -25,7 +26,7 @@ def request_recommendations(body):
     channel.basic_publish(exchange='',
                           routing_key='user_id',
                           body=pickle.dumps(body),
-                          properties=pika.BasicProperties(),
+                          properties=pika.BasicProperties(priority=TG_BOT_PRIORITY),
                           )
     logger.info(f'send recommendation request for user {body["user_id"]} with novelty_level {body["novelty_level"]}')
 


### PR DESCRIPTION
- добавил приоритеты в очередь парсера
- поставил чат боту более высокий приоритет, чем пауку (у него дефолтный = min)

веб серверу тоже нужно будет поднять приоритет, чтобы его сообщения не ждали долго